### PR TITLE
support sha2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir /etc/openldap/slapd.d \
   && mkdir /var/lib/openldap/run \
   && chown ldap:ldap /var/lib/openldap/run
 
-COPY start-slapd.sh /var/lib/openldap/start-salpd.sh
+COPY start-slapd.sh /var/lib/openldap/start-slapd.sh
 COPY restore.sh /var/lib/openldap/restore.sh
 COPY restore-config.sh /var/lib/openldap/restore-config.sh
 RUN chmod +x /var/lib/openldap/*.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.10
+FROM alpine:3.18
 
 RUN  apk update \
-  && apk add gettext openldap openldap-clients openldap-back-mdb openldap-passwd-pbkdf2 openldap-overlay-memberof openldap-overlay-ppolicy openldap-overlay-refint supervisor \
+  && apk add gettext openldap openldap-clients openldap-back-mdb openldap-passwd-pbkdf2 openldap-overlay-memberof openldap-overlay-ppolicy openldap-overlay-refint supervisor openssl openldap-passwd-sha2 \
   && rm -rf /var/cache/apk/* \
   && mkdir -p /ldap
 
@@ -10,6 +10,7 @@ EXPOSE 636
 
 WORKDIR /root
 RUN cp /etc/openldap/slapd.conf . \
+  && echo "moduleload pw-sha2.so" >> slapd.conf \
   && echo "include /etc/openldap/schema/cosine.schema" >> slapd.conf \
   && echo "include /etc/openldap/schema/inetorgperson.schema" >> slapd.conf \
   && echo "include /etc/openldap/schema/nis.schema" >> slapd.conf

--- a/supervisord.slapd.ini
+++ b/supervisord.slapd.ini
@@ -1,5 +1,5 @@
 [program:slapd]
-command=/bin/sh /var/lib/openldap/start-salpd.sh
+command=/bin/sh /var/lib/openldap/start-slapd.sh
 stderr_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
sha2 モジュールをサポートするように修正しました。
また、alpine を 3.18 にバージョンアップしました。
alpine を 3.18 にバージョンアップすることで、OpenLDAP は 2.6.5 がインストールされるようになります。