### PR TITLE
openldapのアップデートにより設定の追加が不要になったため、Dockerfileを修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,7 @@ EXPOSE 636
 
 WORKDIR /root
 RUN cp /etc/openldap/slapd.conf . \
-  && echo "moduleload pw-sha2.so" >> slapd.conf \
-  && echo "include /etc/openldap/schema/cosine.schema" >> slapd.conf \
-  && echo "include /etc/openldap/schema/inetorgperson.schema" >> slapd.conf \
-  && echo "include /etc/openldap/schema/nis.schema" >> slapd.conf
+  && echo "moduleload pw-sha2.so" >> slapd.conf
 
 RUN mkdir /etc/openldap/slapd.d \
   && slaptest -f slapd.conf -F /etc/openldap/slapd.d \


### PR DESCRIPTION
# What
Dockerfileを修正
# Why
openldapのアップデートによりスキーマを取り込むための記述がデフォルトで slapd.conf に入っているため、Dockerfile からの記述の追加が不要になったため、Dockerfile を修正。